### PR TITLE
(New PR) Added leaderboard functionally and unit tests

### DIFF
--- a/src/word_debt_bot/cogs/game_commands.py
+++ b/src/word_debt_bot/cogs/game_commands.py
@@ -67,3 +67,17 @@ class GameCommands(commands.Cog, name="Core Gameplay Module"):
             await ctx.send("Not registered! `.register`")
         except ValueError as err:
             await ctx.send(f"Error: {str(err)}")
+
+    @commands.command(name="leaderboard")
+    async def leaderboard(self, ctx, sort_by: str = "debt", lb_len: int = 5):
+        if not self.game:
+            await ctx.send("Game not loaded. (Yell at Toast more!)")
+            return
+        try:
+            lb = self.game.create_leaderboard(sort_by, lb_len)
+            if lb == "":
+                await ctx.send("No registered users, a leaderboard could not be made!")
+                return
+            await ctx.send(lb)
+        except ValueError as err:
+            await ctx.send(f"Error: {str(err)}")

--- a/src/word_debt_bot/cogs/game_commands.py
+++ b/src/word_debt_bot/cogs/game_commands.py
@@ -69,15 +69,15 @@ class GameCommands(commands.Cog, name="Core Gameplay Module"):
             await ctx.send(f"Error: {str(err)}")
 
     @commands.command(name="leaderboard")
-    async def leaderboard(self, ctx, sort_by: str = "debt", lb_len: int = 5):
+    async def leaderboard(self, ctx, sort_by: str = "debt", req_pg: int = 1):
         if not self.game:
             await ctx.send("Game not loaded. (Yell at Toast more!)")
             return
         try:
-            lb = self.game.create_leaderboard(sort_by, lb_len)
-            if lb == "":
+            pg = self.game.get_leaderboard_page(sort_by, req_pg)
+            if pg == "":
                 await ctx.send("No registered users, a leaderboard could not be made!")
                 return
-            await ctx.send(lb)
+            await ctx.send(pg)
         except ValueError as err:
             await ctx.send(f"Error: {str(err)}")

--- a/src/word_debt_bot/game/core.py
+++ b/src/word_debt_bot/game/core.py
@@ -55,3 +55,25 @@ class WordDebtGame:
         state = self._state
         state[player_id].word_debt += amount
         self._state = state
+
+    def create_leaderboard(self, sort_by: str, lb_len: int):
+        if sort_by not in ["debt", "cranes"]:
+            raise ValueError("ordering is done by 'debt' or 'cranes'")
+        if lb_len < 1:
+            raise ValueError("requested leaderboard length must be 1 or greater")
+        # Make a sort key and sort users
+        if sort_by == "debt":
+            key = lambda u: u[1].word_debt
+        elif sort_by == "cranes":
+            key = lambda u: u[1].cranes
+        users = sorted(self._state.items(), key=key, reverse=True)
+
+        # Produce leaderboard string to return
+        lb = ""
+        i = 1
+        for u in users:
+            lb += f"{i}. {u[1].display_name} - {u[1].word_debt:,} debt - {u[1].cranes:,} cranes\n"
+            i += 1
+            if i > lb_len:
+                break
+        return lb

--- a/src/word_debt_bot/game/core.py
+++ b/src/word_debt_bot/game/core.py
@@ -57,23 +57,26 @@ class WordDebtGame:
         self._state = state
 
     def create_leaderboard(self, sort_by: str, lb_len: int):
+        sort_by = sort_by.lower()
         if sort_by not in ["debt", "cranes"]:
             raise ValueError("ordering is done by 'debt' or 'cranes'")
         if lb_len < 1:
             raise ValueError("requested leaderboard length must be 1 or greater")
         # Make a sort key and sort users
         if sort_by == "debt":
-            key = lambda u: u[1].word_debt
+            key = lambda u: u.word_debt
         elif sort_by == "cranes":
-            key = lambda u: u[1].cranes
-        users = sorted(self._state.items(), key=key, reverse=True)
-
+            key = lambda u: u.cranes
+        users = sorted(self._state.values(), key=key, reverse=True)
+        users = list(enumerate(users, start=1))
         # Produce leaderboard string to return
         lb = ""
-        i = 1
-        for u in users:
-            lb += f"{i}. {u[1].display_name} - {u[1].word_debt:,} debt - {u[1].cranes:,} cranes\n"
-            i += 1
-            if i > lb_len:
+        for i, u in users[:lb_len]:
+            entry = (
+                f"{i}. {u.display_name} - {u.word_debt:,} debt - {u.cranes:,} cranes\n"
+            )
+            if len(lb + entry) > 2000:
                 break
+            lb += entry
+
         return lb

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -73,3 +73,26 @@ def test_game_rejects_negative_debt(
     game_state.register_player(player)
     with pytest.raises(ValueError):
         game_state.add_debt(player.user_id, -10000)
+
+
+def test_game_rejects_invalid_leaderboard_length(game_state: game.WordDebtGame):
+    with pytest.raises(ValueError):
+        game_state.create_leaderboard("debt", 0)
+
+
+def test_game_rejects_invalid_leaderboard_sorting(game_state: game.WordDebtGame):
+    with pytest.raises(ValueError):
+        game_state.create_leaderboard("INVALID", 1)
+
+
+def test_game_produces_valid_leaderboard(
+    game_state: game.WordDebtGame, player: game.WordDebtPlayer
+):
+    player.display_name = "test_name"
+    player.word_debt = 10000
+    player.cranes = 0
+    game_state.register_player(player)
+    assert (
+        game_state.create_leaderboard("debt", 1)
+        == f"1. {player.display_name} - {player.word_debt:,} debt - {player.cranes:,} cranes\n"
+    )

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -75,14 +75,14 @@ def test_game_rejects_negative_debt(
         game_state.add_debt(player.user_id, -10000)
 
 
-def test_game_rejects_invalid_leaderboard_length(game_state: game.WordDebtGame):
+def test_game_rejects_invalid_leaderboard_page_request(game_state: game.WordDebtGame):
     with pytest.raises(ValueError):
-        game_state.create_leaderboard("debt", 0)
+        game_state.get_leaderboard_page("debt", 0)
 
 
 def test_game_rejects_invalid_leaderboard_sorting(game_state: game.WordDebtGame):
     with pytest.raises(ValueError):
-        game_state.create_leaderboard("INVALID", 1)
+        game_state.get_leaderboard_page("INVALID", 1)
 
 
 def test_game_produces_valid_leaderboard(
@@ -93,6 +93,6 @@ def test_game_produces_valid_leaderboard(
     player.cranes = 0
     game_state.register_player(player)
     assert (
-        game_state.create_leaderboard("debt", 1)
+        game_state.get_leaderboard_page("debt", 1)
         == f"1. {player.display_name} - {player.word_debt:,} debt - {player.cranes:,} cranes\n"
     )

--- a/tests/test_game_commands_cog.py
+++ b/tests/test_game_commands_cog.py
@@ -128,3 +128,22 @@ async def test_submit_words_no_game(
     await game_commands_cog.log(game_commands_cog, ctx, 1000)
 
     ctx.send.assert_called_with(String() & Regex("Game not loaded.*"))
+
+
+@pytest.mark.asyncio
+async def test_request_leaderboard_no_register(game_commands_cog: cogs.GameCommands):
+    ctx = AsyncMock()
+
+    await game_commands_cog.leaderboard(game_commands_cog, ctx)
+
+    ctx.send.assert_called_with(String() & Regex("No registered users.*"))
+
+
+@pytest.mark.asyncio
+async def test_request_leaderboard_no_game(game_commands_cog: cogs.GameCommands):
+    ctx = AsyncMock()
+    game_commands_cog.game = None
+
+    await game_commands_cog.leaderboard(game_commands_cog, ctx)
+
+    ctx.send.assert_called_with(String() & Regex("Game not loaded.*"))


### PR DESCRIPTION
### Targets Issue Leaderboard command #5

To avoid any further unnecessary notifications with actions taken to remedy the prior pull request I just created a new branch and properly pointed to dev as its upstream branch then applied changes too it. Afterwards I tested the functionally again and ran the unit tests again with working results.

Again, sorry for the confusion.

### Implements 

`leaderboard()` function in `game_commands.py`

`create_leaderboard()` method in `core.py`

`test_game_rejects_invalid_leaderboard_length()` in `test_game.py`

`test_game_rejects_invalid_leaderboard_sorting()` in `test_game.py`

`test_game_produces_valid_leaderboard()` in `test_game.py`

`test_request_leaderboard_no_register()` in `test_game_commands.py`

`test_request_leaderboard_no_game()` in `test_game_commands.py`


The default values for the leaderboard command are 'debt' and 5 therefore sending a bot message with the top 5 users based on debt, but users can input cranes and any other length. 

Achieved functionality:
```
>.leaderboard
1. user1 - 10,000 debt - 0 cranes
2. user2 - 8,989 debt - 2 cranes

>.leaderboard cranes
1. user2 - 8,989 debt - 2 cranes
2. user1 - 10,000 debt - 0 cranes

>.leaderboard debt 1
1. user1 - 10,000 debt - 0 cranes
```

Though with this solution it requires the user to enter a sorting type if they wish to enter a leaderboard length requirement.


### Unit Tests

#### test_game.py 

`test_game_rejects_invalid_leaderboard_length()` 
Checks proper rejection of a requested leaderboard length < 1.

`test_game_rejects_invalid_leaderboard_sorting()`
Checks proper rejection of an invalid sorting key, ie != "debt" or "cranes".

`test_game_produces_valid_leaderboard()` 
Checks proper leaderboard layout given 1 player and test values.

#### test_game_commands_cog.py 

`test_request_leaderboard_no_register()`
Checks command properly informs users if no one has registered and a leaderboard cannot be made.

`test_request_leaderboard_no_game()`
Checks command properly informs users when the game has not been properly loaded.

-Greg