### PR TITLE
Hotfix: Annotate genre in journal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "word_debt_bot"
-version = "1.0.1"
+version = "1.0.2"
 description = "A Discord bot for running a little reading game."
 authors = ["Simeon Widdis <sawiddis@gmail.com>"]
 license = "MIT"

--- a/src/word_debt_bot/cogs/game_commands.py
+++ b/src/word_debt_bot/cogs/game_commands.py
@@ -1,10 +1,9 @@
 import importlib.metadata
 import json
 import pathlib
-import subprocess
+import typing
 from datetime import datetime
 
-import discord
 import discord.ext.commands as commands
 
 import word_debt_bot.client as client
@@ -55,13 +54,20 @@ class GameCommands(commands.Cog, name="Core Gameplay Module"):
             await ctx.send("Already registered!")
 
     @commands.command(name="log")
-    async def log(self, ctx, words: int):
+    async def log(self, ctx, words: int, genre: typing.Optional[str] = None):
         if not self.game:
             await ctx.send("Game not loaded. (Yell at Toast!)")
             return
         try:
             new_debt = self.game.submit_words(str(ctx.author.id), words)
-            self.journal({"command": "log", "words": words, "user": str(ctx.author.id)})
+            journal_entry = {
+                "command": "log",
+                "words": words,
+                "user": str(ctx.author.id),
+            }
+            if genre:
+                journal_entry["genre"] = genre
+            self.journal(journal_entry)
             await ctx.send(f"Logged {words:,} words! New debt: {new_debt:,}")
         except KeyError as _err:
             await ctx.send("Not registered! `.register`")


### PR DESCRIPTION
To backfill logs with bonus genres accurately, annotations are needed. This adds the annotations as a hotfix to avoid needing to manually update more logs before journal replay.