### PR TITLE
Add more tests for main and error cog

### DIFF
--- a/src/word_debt_bot/cogs/cmd_err_handler.py
+++ b/src/word_debt_bot/cogs/cmd_err_handler.py
@@ -67,31 +67,15 @@ class CmdErrHandler(commands.Cog, name="Command Error Handler"):
                 )
 
     async def handle_invoke_error(self, cause, ctx):
-        if isinstance(cause, ValueError) and ctx.command.name == "register":
-            await ctx.send("Already registered!")
-
-        elif isinstance(cause, KeyError) and ctx.command.name == "log":
-            await ctx.send("Not registered! `.register`")
-
-        elif isinstance(cause, ValueError) and ctx.command.name == "log":
-            await ctx.send(f"Error: {str(cause)}")
-
-        elif isinstance(cause, ValueError) and ctx.command.name == "leaderboard":
-            await ctx.send(f"Error: {str(cause)}")
-
-        elif isinstance(cause, AttributeError) and ctx.command.name == "info":
-            await ctx.send("Not registered! `.register`")
-
-        elif isinstance(cause, ValueError) and ctx.command.name == "buy":
-            await ctx.send(f"Error: {str(cause)}")
-
-        elif isinstance(cause, KeyError) and ctx.command.name == "buy":
-            await ctx.send("Not registered! `.register`")
-
-        else:
-            await ctx.send(
-                f"An unhandled error occured when invoking {ctx.command}!\n"
-                f"Error: {str(cause)}\n"
-                f"Type: {type(cause)}\n"
-                f"For more information type `.help {ctx.command}`\n"
-            )
+        match cause:
+            case ValueError():
+                await ctx.send(f"Error: {str(cause)}")
+            case KeyError():
+                await ctx.send("Not registered! `.register`")
+            case _:
+                await ctx.send(
+                    f"An unhandled error occured when invoking {ctx.command}!\n"
+                    f"Error: {str(cause)}\n"
+                    f"Type: {type(cause)}\n"
+                    f"For more information type `.help {ctx.command}`\n"
+                )

--- a/src/word_debt_bot/cogs/cmd_err_handler.py
+++ b/src/word_debt_bot/cogs/cmd_err_handler.py
@@ -24,81 +24,74 @@ class CmdErrHandler(commands.Cog, name="Command Error Handler"):
         if hasattr(ctx.command, "on_error"):
             return
 
-        # Prevents responses to commands that the bot does not have
-        if isinstance(err, commands.CommandNotFound):
-            return
+        match err:
+            case commands.CommandNotFound():
+                return
+            case commands.DisabledCommand():
+                await ctx.send(f"Sorry, {ctx.command} is currently disabled.\n")
+            case commands.MissingPermissions():
+                await ctx.send(
+                    f"Sorry, you do not have the required permissions for {ctx.command}.\n"
+                )
+            case commands.MissingRole():
+                await ctx.send(
+                    f"Sorry, you do not have the required role for {ctx.command}.\n"
+                )
+            case commands.MissingAnyRole():
+                await ctx.send(
+                    f"Sorry, you do not have all the required roles for {ctx.command}.\n"
+                )
+            case commands.BadArgument():
+                await ctx.send(
+                    f"Invalid inputs were supplied for {ctx.command}!\n"
+                    f"For more information type `.help {ctx.command}`"
+                )
+            case commands.MissingRequiredArgument():
+                await ctx.send(
+                    f"Not all required inputs were given for {ctx.command}!\n"
+                    f"For more information type `.help {ctx.command}`"
+                )
+            case commands.ExpectedClosingQuoteError():
+                await ctx.send(
+                    f"A quote was missing for command {ctx.command}!\n"
+                    f"For more information type `.help {ctx.command}`"
+                )
+            case commands.CommandInvokeError():
+                await self.handle_invoke_error(err.__cause__, ctx)
+            case _:
+                await ctx.send(
+                    f"An unhandled error occured when invoking {ctx.command}!\n"
+                    f"Error: {str(err)}\n"
+                    f"Type: {type(err)}\n"
+                    f"For more information type `.help {ctx.command}`\n"
+                )
 
-        if isinstance(err, commands.DisabledCommand):
-            await ctx.send(f"Sorry, {ctx.command} is currently disabled.\n")
-
-        elif isinstance(err, commands.MissingPermissions):
-            await ctx.send(
-                f"Sorry, you do not have the required permissions for {ctx.command}.\n"
-            )
-
-        elif isinstance(err, commands.MissingRole):
-            await ctx.send(
-                f"Sorry, you do not have the required role for {ctx.command}.\n"
-            )
-
-        elif isinstance(err, commands.MissingAnyRole):
-            await ctx.send(
-                f"Sorry, you do not have all the required roles for {ctx.command}.\n"
-            )
-
-        elif isinstance(err, commands.BadArgument):
-            await ctx.send(
-                f"Invalid inputs were supplied for {ctx.command}!\n"
-                f"For more information type `.help {ctx.command}`"
-            )
-
-        elif isinstance(err, commands.MissingRequiredArgument):
-            await ctx.send(
-                f"Not all required inputs were given for {ctx.command}!\n"
-                f"For more information type `.help {ctx.command}`"
-            )
-
-        elif isinstance(err, commands.ExpectedClosingQuoteError):
-            await ctx.send(
-                f"A quote was missing for command {ctx.command}!\n"
-                f"For more information type `.help {ctx.command}`"
-            )
-
-        elif isinstance(err.__cause__, ValueError) and ctx.command.name == "register":
+    async def handle_invoke_error(self, cause, ctx):
+        if isinstance(cause, ValueError) and ctx.command.name == "register":
             await ctx.send("Already registered!")
 
-        elif isinstance(err.__cause__, KeyError) and ctx.command.name == "log":
+        elif isinstance(cause, KeyError) and ctx.command.name == "log":
             await ctx.send("Not registered! `.register`")
 
-        elif isinstance(err.__cause__, ValueError) and ctx.command.name == "log":
-            await ctx.send(f"Error: {str(err.__cause__)}")
+        elif isinstance(cause, ValueError) and ctx.command.name == "log":
+            await ctx.send(f"Error: {str(cause)}")
 
-        elif (
-            isinstance(err.__cause__, ValueError) and ctx.command.name == "leaderboard"
-        ):
-            await ctx.send(f"Error: {str(err.__cause__)}")
+        elif isinstance(cause, ValueError) and ctx.command.name == "leaderboard":
+            await ctx.send(f"Error: {str(cause)}")
 
-        elif isinstance(err.__cause__, AttributeError) and ctx.command.name == "info":
+        elif isinstance(cause, AttributeError) and ctx.command.name == "info":
             await ctx.send("Not registered! `.register`")
 
-        elif isinstance(err.__cause__, ValueError) and ctx.command.name == "buy":
-            await ctx.send(f"Error: {str(err.__cause__)}")
+        elif isinstance(cause, ValueError) and ctx.command.name == "buy":
+            await ctx.send(f"Error: {str(cause)}")
 
-        elif isinstance(err.__cause__, KeyError) and ctx.command.name == "buy":
+        elif isinstance(cause, KeyError) and ctx.command.name == "buy":
             await ctx.send("Not registered! `.register`")
-
-        elif isinstance(err, commands.CommandInvokeError):
-            await ctx.send(
-                f"An error occured when invoking {ctx.command}!\n"
-                f"Error: {str(err)}\n"
-                f"Type: {type(err)}\n"
-                f"For more information type `.help {ctx.command}`\n"
-            )
 
         else:
             await ctx.send(
                 f"An unhandled error occured when invoking {ctx.command}!\n"
-                f"Error: {str(err)}\n"
-                f"Type: {type(err)}\n"
+                f"Error: {str(cause)}\n"
+                f"Type: {type(cause)}\n"
                 f"For more information type `.help {ctx.command}`\n"
             )

--- a/src/word_debt_bot/cogs/cmd_err_handler.py
+++ b/src/word_debt_bot/cogs/cmd_err_handler.py
@@ -27,20 +27,6 @@ class CmdErrHandler(commands.Cog, name="Command Error Handler"):
         match err:
             case commands.CommandNotFound():
                 return
-            case commands.DisabledCommand():
-                await ctx.send(f"Sorry, {ctx.command} is currently disabled.\n")
-            case commands.MissingPermissions():
-                await ctx.send(
-                    f"Sorry, you do not have the required permissions for {ctx.command}.\n"
-                )
-            case commands.MissingRole():
-                await ctx.send(
-                    f"Sorry, you do not have the required role for {ctx.command}.\n"
-                )
-            case commands.MissingAnyRole():
-                await ctx.send(
-                    f"Sorry, you do not have all the required roles for {ctx.command}.\n"
-                )
             case commands.BadArgument():
                 await ctx.send(
                     f"Invalid inputs were supplied for {ctx.command}!\n"
@@ -51,11 +37,6 @@ class CmdErrHandler(commands.Cog, name="Command Error Handler"):
                     f"Not all required inputs were given for {ctx.command}!\n"
                     f"For more information type `.help {ctx.command}`"
                 )
-            case commands.ExpectedClosingQuoteError():
-                await ctx.send(
-                    f"A quote was missing for command {ctx.command}!\n"
-                    f"For more information type `.help {ctx.command}`"
-                )
             case commands.CommandInvokeError():
                 await self.handle_invoke_error(err.__cause__, ctx)
             case _:
@@ -63,7 +44,7 @@ class CmdErrHandler(commands.Cog, name="Command Error Handler"):
                     f"An unhandled error occured when invoking {ctx.command}!\n"
                     f"Error: {str(err)}\n"
                     f"Type: {type(err)}\n"
-                    f"For more information type `.help {ctx.command}`\n"
+                    f"For more information type `.help {ctx.command}` (and report this error to Toast!)\n"
                 )
 
     async def handle_invoke_error(self, cause, ctx):

--- a/src/word_debt_bot/cogs/game_commands.py
+++ b/src/word_debt_bot/cogs/game_commands.py
@@ -62,7 +62,7 @@ class GameCommands(commands.Cog, name="Core Gameplay"):
         """
         Check your current cranes and debt.
         """
-        player = self.game.get_player(str(ctx.author.id))
+        player = self.game.get_player(str(ctx.author.id), False)
         await ctx.send(
             f"Info for {player.display_name}:\nDebt: {player.word_debt:,}\nCranes: {player.cranes:,}"
         )

--- a/src/word_debt_bot/game/core.py
+++ b/src/word_debt_bot/game/core.py
@@ -62,12 +62,15 @@ class WordDebtGame:
     def register_player(self, player: WordDebtPlayer):
         state = self._state
         if player.user_id in state.users:
-            raise ValueError(f"Player with id {player.user_id} already exists")
+            raise ValueError(f"already registered!")
         state.users[player.user_id] = player
         self._state = state
 
-    def get_player(self, player_id: str) -> WordDebtPlayer | None:
-        return self._state.users.get(player_id)
+    def get_player(self, player_id: str, optional=True) -> WordDebtPlayer | None:
+        if optional:  # Don't throw a KeyError if missing
+            return self._state.users.get(player_id)
+        else:
+            return self._state.users[player_id]
 
     def submit_words(
         self, player_id: str, amount: int, genre: str | None = None

--- a/src/word_debt_bot/main.py
+++ b/src/word_debt_bot/main.py
@@ -19,10 +19,10 @@ def get_token(token_path):
         return token_file.read()
 
 
-def make_bot():
-    intents = discord.Intents.default()
-    intents.message_content = True
-    intents.members = True
+def make_bot(intents=None):
+    if intents is None:
+        intents = discord.Intents.default()
+        intents.message_content = True
     return WordDebtBot(".", intents=intents)
 
 

--- a/src/word_debt_bot/main.py
+++ b/src/word_debt_bot/main.py
@@ -22,6 +22,7 @@ def get_token(token_path):
 def make_bot():
     intents = discord.Intents.default()
     intents.message_content = True
+    intents.members = True
     return WordDebtBot(".", intents=intents)
 
 

--- a/src/word_debt_bot/main.py
+++ b/src/word_debt_bot/main.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import os
-import pathlib
+from pathlib import Path
 
 import discord
 
@@ -19,24 +19,30 @@ def get_token(token_path):
         return token_file.read()
 
 
-if __name__ == "__main__":
-    # Config
+def make_bot():
     intents = discord.Intents.default()
     intents.message_content = True
-    handler = logging.FileHandler(
-        filename=pathlib.Path("data/discord.log"), encoding="utf-8", mode="a"
-    )
+    return WordDebtBot(".", intents=intents)
 
-    # Loading data
-    game = WordDebtGame(pathlib.Path("data/prod.json"))
-    token = get_token(pathlib.Path("data/TOKEN"))
 
-    # Starting the bot
-    bot = WordDebtBot(".", intents=intents)
-
+def add_cogs(bot: WordDebtBot, game: WordDebtGame):
     loop = asyncio.get_event_loop()
     tasks = [loop.create_task(bot.add_cog(cogs.GameCommands(bot, game)))]
     loop.run_until_complete(asyncio.wait(tasks))
     loop.close()
 
+
+def main(log_file: Path, state_file: Path, token_file: Path):
+    # Set up bot
+    game = WordDebtGame(state_file)
+    bot = make_bot()
+    add_cogs(bot, game)
+
+    # Startup
+    token = get_token(token_file)
+    handler = logging.FileHandler(filename=log_file, encoding="utf-8", mode="a")
     bot.run(token, log_handler=handler, log_level=logging.INFO)
+
+
+if __name__ == "__main__":
+    main(Path("data/discord.log"), Path("data/prod.json"), Path("data/TOKEN"))

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -28,12 +28,7 @@ def game_commands_cog(game_state, tmp_path) -> cogs.GameCommands:
 
 @pytest.fixture
 def cmd_err_handler_cog(game_state) -> cogs.CmdErrHandler:
-    intents = discord.Intents.default()
-    intents.message_content = True
-
-    # Dummy bot required as cog argument -- For bot access use bot fixture
-    bot = client.WordDebtBot(command_prefix=".", intents=intents)
-
+    bot = main.make_bot()
     return cogs.CmdErrHandler(bot, game_state)
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,7 @@
 import random
 import string
 
+import discord
 import discord.ext.test as dpytest
 import pytest
 import pytest_asyncio
@@ -34,7 +35,10 @@ def cmd_err_handler_cog(game_state) -> cogs.CmdErrHandler:
 
 @pytest_asyncio.fixture
 async def bot(game_state, tmp_path) -> client.WordDebtBot:
-    bot = main.make_bot()
+    intents = discord.Intents.default()
+    intents.message_content = True
+    intents.members = True
+    bot = main.make_bot(intents)
     await bot._async_setup_hook()
     await bot.add_cog(cogs.GameCommands(bot, game_state, tmp_path / "journal.ndjson"))
     await bot.add_cog(cogs.CmdErrHandler(bot, game_state))

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,12 +1,11 @@
 import random
 import string
 
-import discord
 import discord.ext.test as dpytest
 import pytest
 import pytest_asyncio
 
-from word_debt_bot import client, cogs, game
+from word_debt_bot import client, cogs, game, main
 
 
 @pytest.fixture
@@ -23,22 +22,13 @@ def player() -> game.WordDebtPlayer:
 
 @pytest.fixture
 def game_commands_cog(game_state, tmp_path) -> cogs.GameCommands:
-    intents = discord.Intents.default()
-    intents.message_content = True
-
-    # Dummy bot required as cog argument -- For bot access use bot fixture
-    bot = client.WordDebtBot(command_prefix=".", intents=intents)
-
+    bot = main.make_bot()
     return cogs.GameCommands(bot, game_state, tmp_path / "journal.ndjson")
 
 
 @pytest_asyncio.fixture
 async def bot(game_state, tmp_path) -> client.WordDebtBot:
-    intents = discord.Intents.default()
-    intents.message_content = True
-    intents.members = True  # Not required for actual bot but needed for test framework
-
-    bot = client.WordDebtBot(command_prefix=".", intents=intents)
+    bot = main.make_bot()
     await bot._async_setup_hook()
     await bot.add_cog(cogs.GameCommands(bot, game_state, tmp_path / "journal.ndjson"))
     dpytest.configure(bot)

--- a/tests/test_err_handler.py
+++ b/tests/test_err_handler.py
@@ -1,0 +1,111 @@
+import copy
+from unittest.mock import AsyncMock
+
+import pytest
+from callee import Regex, String
+from discord.ext import commands
+
+from word_debt_bot import game as game_lib
+
+from .fixtures import *
+
+
+@pytest.mark.asyncio
+async def test_registration_valueerror(
+    bot: client.WordDebtBot, player: game_lib.WordDebtPlayer
+):
+    ctx = AsyncMock()
+    ctx.author.id = player.user_id
+    ctx.author.name = player.display_name
+    game_cmds_cog = bot.get_cog("Core Gameplay")
+    cmd_err_cog = bot.get_cog("Command Error Handler")
+
+    await game_cmds_cog.register.invoke(ctx)
+    with pytest.raises(commands.CommandInvokeError) as err:
+        await game_cmds_cog.register.invoke(ctx)
+
+    await cmd_err_cog.on_command_error(ctx, err.value)
+
+    ctx.send.assert_called_with("Already registered!")
+
+
+@pytest.mark.asyncio
+async def test_submit_words_with_error(
+    bot: client.WordDebtBot, player: game_lib.WordDebtPlayer
+):
+    ctx = AsyncMock()
+    ctx.author.id = player.user_id
+    game_cmds_cog = bot.get_cog("Core Gameplay")
+    cmd_err_cog = bot.get_cog("Command Error Handler")
+    game_cmds_cog.game.register_player(player)
+
+    @bot.command()
+    async def log_test_m1k(ctx, words=-1000):
+        await game_cmds_cog.log(ctx, words, genre=None)
+
+    game_cmds_cog.log_test_m1k = log_test_m1k
+
+    with pytest.raises(commands.CommandInvokeError) as err:
+        await game_cmds_cog.log_test_m1k.invoke(ctx)
+
+    ctx.command.name = "log"
+
+    await cmd_err_cog.on_command_error(ctx, err.value)
+
+    ctx.send.assert_called_with(String() & Regex("Error:.*"))
+
+
+@pytest.mark.asyncio
+async def test_submit_words_with_no_register(
+    bot: client.WordDebtBot, player: game_lib.WordDebtPlayer
+):
+    ctx = AsyncMock()
+    ctx.author.id = player.user_id
+    game_cmds_cog = bot.get_cog("Core Gameplay")
+    cmd_err_cog = bot.get_cog("Command Error Handler")
+
+    @bot.command()
+    async def log_test_10(ctx, words=10):
+        await game_cmds_cog.log(ctx, words, None)
+
+    game_cmds_cog.log_test_10 = log_test_10
+
+    with pytest.raises(commands.CommandInvokeError) as err:
+        await game_cmds_cog.log_test_10.invoke(ctx)
+
+    ctx.command.name = "log"
+
+    await cmd_err_cog.on_command_error(ctx, err.value)
+
+    ctx.send.assert_called_with(String() & Regex("Not registered!.*"))
+
+
+@pytest.mark.asyncio
+async def test_buy_with_value_error(
+    bot: client.WordDebtBot, player: game_lib.WordDebtPlayer
+):
+    ctx = AsyncMock()
+    ctx.author.id = player.user_id
+    target_player = copy.copy(player)
+    target_player.user_id = "12345"
+    game_cmds_cog = bot.get_cog("Core Gameplay")
+    cmd_err_cog = bot.get_cog("Command Error Handler")
+    game_cmds_cog.game.register_player(player)
+    game_cmds_cog.game.register_player(target_player)
+
+    @bot.command()
+    async def buy_test_err(ctx):
+        await game_cmds_cog.buy(
+            ctx, "debt increase", args=f"<@{target_player.user_id}>"
+        )
+
+    game_cmds_cog.buy_test_err = buy_test_err
+
+    with pytest.raises(commands.CommandInvokeError) as err:
+        await game_cmds_cog.buy_test_err.invoke(ctx)
+
+    ctx.command.name = "buy"
+
+    await cmd_err_cog.on_command_error(ctx, err.value)
+
+    ctx.send.assert_called_with("Error: insufficient cranes")

--- a/tests/test_err_handler.py
+++ b/tests/test_err_handler.py
@@ -26,7 +26,7 @@ async def test_registration_valueerror(
 
     await cmd_err_cog.on_command_error(ctx, err.value)
 
-    ctx.send.assert_called_with("Already registered!")
+    ctx.send.assert_called_with("Error: already registered!")
 
 
 @pytest.mark.asyncio

--- a/tests/test_err_handler.py
+++ b/tests/test_err_handler.py
@@ -109,3 +109,37 @@ async def test_buy_with_value_error(
     await cmd_err_cog.on_command_error(ctx, err.value)
 
     ctx.send.assert_called_with("Error: insufficient cranes")
+
+
+@pytest.mark.asyncio
+async def test_missing_args(bot):
+    await dpytest.message(".register")
+    await dpytest.empty_queue()
+
+    with pytest.raises(commands.MissingRequiredArgument):
+        await dpytest.message(".log")
+
+    assert (
+        dpytest.verify()
+        .message()
+        .contains()
+        .content("Not all required inputs were given")
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_args(bot):
+    await dpytest.message(".register")
+    await dpytest.empty_queue()
+
+    with pytest.raises(commands.BadArgument):
+        await dpytest.message(".log fiction")
+
+    assert dpytest.verify().message().contains().content("Invalid inputs were supplied")
+
+
+@pytest.mark.asyncio
+async def test_invalid_command(bot):
+    with pytest.raises(commands.CommandNotFound):
+        await dpytest.message(".nonexistent")
+    assert dpytest.verify().message().nothing()

--- a/tests/test_game_commands_cog.py
+++ b/tests/test_game_commands_cog.py
@@ -1,10 +1,7 @@
-import copy
-import re
 from unittest.mock import AsyncMock
 
 import pytest
 from callee import Regex, String
-from discord.ext import commands
 
 from word_debt_bot import cogs
 from word_debt_bot import game as game_lib
@@ -45,25 +42,6 @@ async def test_registration(
 
 
 @pytest.mark.asyncio
-async def test_registration_valueerror(
-    bot: client.WordDebtBot, player: game_lib.WordDebtPlayer
-):
-    ctx = AsyncMock()
-    ctx.author.id = player.user_id
-    ctx.author.name = player.display_name
-    game_cmds_cog = bot.get_cog("Core Gameplay")
-    cmd_err_cog = bot.get_cog("Command Error Handler")
-
-    await game_cmds_cog.register.invoke(ctx)
-    with pytest.raises(commands.CommandInvokeError) as err:
-        await game_cmds_cog.register.invoke(ctx)
-
-    await cmd_err_cog.on_command_error(ctx, err.value)
-
-    ctx.send.assert_called_with("Already registered!")
-
-
-@pytest.mark.asyncio
 async def test_submit_words(
     game_commands_cog: cogs.GameCommands, player: game_lib.WordDebtPlayer
 ):
@@ -77,94 +55,12 @@ async def test_submit_words(
 
 
 @pytest.mark.asyncio
-async def test_submit_words_with_error(
-    bot: client.WordDebtBot, player: game_lib.WordDebtPlayer
-):
-    ctx = AsyncMock()
-    ctx.author.id = player.user_id
-    game_cmds_cog = bot.get_cog("Core Gameplay")
-    cmd_err_cog = bot.get_cog("Command Error Handler")
-    game_cmds_cog.game.register_player(player)
-
-    @bot.command()
-    async def log_test_m1k(ctx, words=-1000):
-        await game_cmds_cog.log(ctx, words, genre=None)
-
-    game_cmds_cog.log_test_m1k = log_test_m1k
-
-    with pytest.raises(commands.CommandInvokeError) as err:
-        await game_cmds_cog.log_test_m1k.invoke(ctx)
-
-    ctx.command.name = "log"
-
-    await cmd_err_cog.on_command_error(ctx, err.value)
-
-    ctx.send.assert_called_with(String() & Regex("Error:.*"))
-
-
-@pytest.mark.asyncio
-async def test_submit_words_with_no_register(
-    bot: client.WordDebtBot, player: game_lib.WordDebtPlayer
-):
-    ctx = AsyncMock()
-    ctx.author.id = player.user_id
-    game_cmds_cog = bot.get_cog("Core Gameplay")
-    cmd_err_cog = bot.get_cog("Command Error Handler")
-
-    @bot.command()
-    async def log_test_10(ctx, words=10):
-        await game_cmds_cog.log(ctx, words, None)
-
-    game_cmds_cog.log_test_10 = log_test_10
-
-    with pytest.raises(commands.CommandInvokeError) as err:
-        await game_cmds_cog.log_test_10.invoke(ctx)
-
-    ctx.command.name = "log"
-
-    await cmd_err_cog.on_command_error(ctx, err.value)
-
-    ctx.send.assert_called_with(String() & Regex("Not registered!.*"))
-
-
-@pytest.mark.asyncio
 async def test_request_leaderboard_no_register(game_commands_cog: cogs.GameCommands):
     ctx = AsyncMock()
 
     await game_commands_cog.leaderboard(game_commands_cog, ctx, "debt", 1)
 
     ctx.send.assert_called_with(String() & Regex("No registered users.*"))
-
-
-@pytest.mark.asyncio
-async def test_buy_with_value_error(
-    bot: client.WordDebtBot, player: game_lib.WordDebtPlayer
-):
-    ctx = AsyncMock()
-    ctx.author.id = player.user_id
-    target_player = copy.copy(player)
-    target_player.user_id = "12345"
-    game_cmds_cog = bot.get_cog("Core Gameplay")
-    cmd_err_cog = bot.get_cog("Command Error Handler")
-    game_cmds_cog.game.register_player(player)
-    game_cmds_cog.game.register_player(target_player)
-
-    @bot.command()
-    async def buy_test_err(ctx):
-        await game_cmds_cog.buy(
-            ctx, "debt increase", args=f"<@{target_player.user_id}>"
-        )
-
-    game_cmds_cog.buy_test_err = buy_test_err
-
-    with pytest.raises(commands.CommandInvokeError) as err:
-        await game_cmds_cog.buy_test_err.invoke(ctx)
-
-    ctx.command.name = "buy"
-
-    await cmd_err_cog.on_command_error(ctx, err.value)
-
-    ctx.send.assert_called_with("Error: insufficient cranes")
 
 
 @pytest.mark.asyncio

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+
+import word_debt_bot.main as main
+from word_debt_bot.game.core import WordDebtGame
+
+from .fixtures import *
+
+
+def test_token_read(tmp_path: Path):
+    with open(tmp_path / "TOKEN", "w") as token_file:
+        token_file.write("sample_token")
+
+    token = main.get_token(tmp_path / "TOKEN")
+
+    assert token == "sample_token"
+
+
+def test_token_read_missing_token(tmp_path: Path):
+    with pytest.raises(FileNotFoundError, match="Missing TOKEN file"):
+        main.get_token(tmp_path / "TOKEN")
+
+
+def test_add_cogs(game_state: WordDebtGame):
+    bot = main.make_bot()
+    main.add_cogs(bot, game_state)
+    assert bot.get_cog("Core Gameplay Module") is not None


### PR DESCRIPTION
As part of reaching a personal goal of having 90%+ coverage, this PR adds unit tests for the bulk of the code in `main`, as well as some further tests for the new error cog, which together account for 40/63 missed lines. Also using this as an excuse to get some other refactoring work in.

Closes #34 

Steps to complete:
- [X] Add coverage for what parts of main are reasonably coverable
- [x] Refactor error cog for better testability
- [x] Write new tests for error cog & other methods to hit target coverage threshold
