### PR TITLE
Add optional name argument for info command

### DIFF
--- a/src/word_debt_bot/cogs/game_commands.py
+++ b/src/word_debt_bot/cogs/game_commands.py
@@ -6,6 +6,7 @@ import re
 import typing
 from datetime import datetime
 
+import discord
 import discord.ext.commands as commands
 
 import word_debt_bot.client as client
@@ -61,7 +62,7 @@ class GameCommands(commands.Cog, name="Core Gameplay"):
     async def info(
         self,
         ctx,
-        name: typing.Optional[str] = commands.parameter(
+        user: typing.Optional[discord.User] = commands.parameter(
             default=None,
             displayed_default=inspect.Parameter.empty,
             description="The player to get info for.",
@@ -70,13 +71,14 @@ class GameCommands(commands.Cog, name="Core Gameplay"):
         """
         Check someone's current cranes and debt. Shows your own info if no name is given.
         """
-        if name:
-            player = self.game.get_player_by_name(name, optional=True)
+        if user:
+            # player = self.game.get_player_by_name(name, optional=True)
+            player = self.game.get_player(str(user.id), optional=True)
         else:
             player = self.game.get_player(str(ctx.author.id), optional=True)
 
         if not player:
-            name = name if name else ctx.author.name
+            name = user.name if user else ctx.author.name
             await ctx.send(f"Player '{name}' not found! Are they registered?")
             return
 

--- a/src/word_debt_bot/cogs/game_commands.py
+++ b/src/word_debt_bot/cogs/game_commands.py
@@ -58,11 +58,28 @@ class GameCommands(commands.Cog, name="Core Gameplay"):
         await ctx.send("Registered with 10,000 debt!")
 
     @commands.command(name="info")
-    async def info(self, ctx):
+    async def info(
+        self,
+        ctx,
+        name: typing.Optional[str] = commands.parameter(
+            default=None,
+            displayed_default=inspect.Parameter.empty,
+            description="The player to get info for.",
+        ),
+    ):
         """
-        Check your current cranes and debt.
+        Check someone's current cranes and debt. Shows your own info if no name is given.
         """
-        player = self.game.get_player(str(ctx.author.id), False)
+        if name:
+            player = self.game.get_player_by_name(name, optional=True)
+        else:
+            player = self.game.get_player(str(ctx.author.id), optional=True)
+
+        if not player:
+            name = name if name else ctx.author.name
+            await ctx.send(f"Player '{name}' not found! Are they registered?")
+            return
+
         await ctx.send(
             f"Info for {player.display_name}:\nDebt: {player.word_debt:,}\nCranes: {player.cranes:,}"
         )

--- a/src/word_debt_bot/game/core.py
+++ b/src/word_debt_bot/game/core.py
@@ -72,6 +72,16 @@ class WordDebtGame:
         else:
             return self._state.users[player_id]
 
+    def get_player_by_name(
+        self, display_name: str, optional=True
+    ) -> WordDebtPlayer | None:
+        for user in self._state.users.values():
+            if user.display_name == display_name:
+                return user
+        if optional:
+            return None
+        raise KeyError(f"No user with display name {display_name}")
+
     def submit_words(
         self, player_id: str, amount: int, genre: str | None = None
     ) -> int:

--- a/src/word_debt_bot/game/core.py
+++ b/src/word_debt_bot/game/core.py
@@ -72,16 +72,6 @@ class WordDebtGame:
         else:
             return self._state.users[player_id]
 
-    def get_player_by_name(
-        self, display_name: str, optional=True
-    ) -> WordDebtPlayer | None:
-        for user in self._state.users.values():
-            if user.display_name == display_name:
-                return user
-        if optional:
-            return None
-        raise KeyError(f"No user with display name {display_name}")
-
     def submit_words(
         self, player_id: str, amount: int, genre: str | None = None
     ) -> int:

--- a/tests/test_game_commands_cog.py
+++ b/tests/test_game_commands_cog.py
@@ -82,13 +82,22 @@ async def test_buy_bonus_genre(
 async def test_info(
     game_commands_cog: cogs.GameCommands, player: game_lib.WordDebtPlayer
 ):
+    # Check info as self (no name given)
     ctx = AsyncMock()
     ctx.author.id = player.user_id
     player.word_debt = 250000
     game_commands_cog.game.register_player(player)
     await game_commands_cog.log(game_commands_cog, ctx, 100000, None)
-    await game_commands_cog.info(game_commands_cog, ctx)
+    await game_commands_cog.info(game_commands_cog, ctx, None)
 
     # Multiline flag is broken, TODO fix and use regular .*
     ctx.send.assert_called_with(String() & Regex(r"(.*\n)*Debt: 150,000(\n.*)*"))
     ctx.send.assert_called_with(String() & Regex(r"(.*\n)*Cranes: 200(\n.*)*"))
+
+    # Check info as someone else
+    await game_commands_cog.log(game_commands_cog, ctx, 100000, None)
+    ctx.author.id = "some.other.player"
+    await game_commands_cog.info(game_commands_cog, ctx, player.display_name)
+
+    ctx.send.assert_called_with(String() & Regex(r"(.*\n)*Debt: 50,000(\n.*)*"))
+    ctx.send.assert_called_with(String() & Regex(r"(.*\n)*Cranes: 400(\n.*)*"))


### PR DESCRIPTION
Closes #36. 

I'm not familiar with BearType, but it complained at me

`E   beartype.roar.BeartypeCallHintParamViolation: Method word_debt_bot.game.core.WordDebtGame.get_player_by_name() parameter display_name=<Parameter "empty=None"> violates type hint <class 'str'> under non-default configuration BeartypeConf(claw_is_pep526=True, is_color=None, is_debug=False, is_pep484_tower=False, strategy=<BeartypeStrategy.O1: 2>, warning_cls_on_decorator_exception=<class 'beartype.roar._roarwarn.BeartypeClawDecorWarning'>), as <class "discord.ext.commands.parameters.Parameter"> <Parameter "empty=None"> not instance of str.`

so I modified

`await game_commands_cog.info(game_commands_cog, ctx)`

to

`await game_commands_cog.info(game_commands_cog, ctx, None)`

I'm assuming this is a limitation of using mocks, and in real usage Discord would pass a None and not a Parameter object. Testing the actual bot live on a Discord server it seems to work both with and without the name. Not sure if you think it's worth modifying how command tests are structured over this.