### PR TITLE
Add shop command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.10"
 beartype = "^0.16.4"
+PyYAML = "^6.0.1"
 "discord.py" = "^2.3.2"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/word_debt_bot/cogs/game_commands.py
+++ b/src/word_debt_bot/cogs/game_commands.py
@@ -39,7 +39,7 @@ class GameCommands(commands.Cog, name="Core Gameplay"):
                         "debt_increase": {
                             "display_name": "debt increase",
                             "description": "Increase another player's debt by 10000.",
-                            "price": 100,
+                            "price": 20,
                         },
                     },
                     file_handle,

--- a/tests/test_data/shop.yaml
+++ b/tests/test_data/shop.yaml
@@ -1,0 +1,8 @@
+bonus_genre:
+  display_name: "bonus genre"
+  price: 200
+  description: "For the next week, words logged with this genre are worth twice as many cranes."
+debt_increase:
+  display_name: "debt increase"
+  price: 100
+  description: "Increase another player's debt by 10000."

--- a/tests/test_data/shop.yaml
+++ b/tests/test_data/shop.yaml
@@ -4,5 +4,5 @@ bonus_genre:
   description: "For the next week, words logged with this genre are worth twice as many cranes."
 debt_increase:
   display_name: "debt increase"
-  price: 100
+  price: 20
   description: "Increase another player's debt by 10000."

--- a/tests/test_game_commands_cog.py
+++ b/tests/test_game_commands_cog.py
@@ -120,5 +120,5 @@ async def test_shop(game_commands_cog: cogs.GameCommands):
     game_commands_cog.shop_path = pathlib.Path("tests/test_data/shop.yaml")
     await game_commands_cog.shop(game_commands_cog, ctx)
     ctx.send.assert_called_with(
-        '- "bonus genre": For the next week, words logged with this genre are worth twice as many cranes. Costs 200 cranes.\n- "debt increase": Increase another player\'s debt by 10000. Costs 100 cranes.\n'
+        '- "bonus genre": For the next week, words logged with this genre are worth twice as many cranes. Costs 200 cranes.\n- "debt increase": Increase another player\'s debt by 10000. Costs 20 cranes.\n'
     )

--- a/tests/test_game_commands_cog.py
+++ b/tests/test_game_commands_cog.py
@@ -1,3 +1,4 @@
+import pathlib
 from unittest.mock import AsyncMock
 
 import pytest
@@ -64,18 +65,37 @@ async def test_request_leaderboard_no_register(game_commands_cog: cogs.GameComma
 
 
 @pytest.mark.asyncio
-async def test_buy_bonus_genre(
+async def test_buy_bonus_genre_sends_buy_message(
     game_commands_cog: cogs.GameCommands, player: game_lib.WordDebtPlayer
 ):
     ctx = AsyncMock()
     ctx.author.id = player.user_id
     game_commands_cog.game.register_player(player)
+    game_commands_cog.shop_path = pathlib.Path("tests/test_data/shop.yaml")
     await game_commands_cog.log(game_commands_cog, ctx, 100000, None)
     await game_commands_cog.buy(
         game_commands_cog, ctx, "bonus genre", args="historical fiction"
     )
 
     ctx.send.assert_called_with("New bonus genre active: historical fiction")
+
+
+@pytest.mark.asyncio
+async def test_buy_bonus_genre_subtracts_correct_price(
+    game_commands_cog: cogs.GameCommands,
+    player: game_lib.WordDebtPlayer,
+    game_state: game_lib.WordDebtGame,
+):
+    ctx = AsyncMock()
+    ctx.author.id = player.user_id
+    game_commands_cog.game.register_player(player)
+    game_commands_cog.shop_path = pathlib.Path("tests/test_data/shop.yaml")
+    await game_commands_cog.log(game_commands_cog, ctx, 300000, None)
+    await game_commands_cog.buy(
+        game_commands_cog, ctx, "bonus genre", args="historical fiction"
+    )
+
+    assert game_state._state.users[player.user_id].cranes == 400
 
 
 @pytest.mark.asyncio
@@ -92,3 +112,13 @@ async def test_info(
     # Multiline flag is broken, TODO fix and use regular .*
     ctx.send.assert_called_with(String() & Regex(r"(.*\n)*Debt: 150,000(\n.*)*"))
     ctx.send.assert_called_with(String() & Regex(r"(.*\n)*Cranes: 200(\n.*)*"))
+
+
+@pytest.mark.asyncio
+async def test_shop(game_commands_cog: cogs.GameCommands):
+    ctx = AsyncMock()
+    game_commands_cog.shop_path = pathlib.Path("tests/test_data/shop.yaml")
+    await game_commands_cog.shop(game_commands_cog, ctx)
+    ctx.send.assert_called_with(
+        '- "bonus genre": For the next week, words logged with this genre are worth twice as many cranes. Costs 200 cranes.\n- "debt increase": Increase another player\'s debt by 10000. Costs 100 cranes.\n'
+    )


### PR DESCRIPTION
Closes #37.

I called it shop instead because I kept getting "store" mixed up in my head with storing things in general. It also sounds casual and fun

I added price logging to the journal entries under the assumption the price list could be modified in a way that isn't tracked in the journal, but I don't know what to do about handling the entries that already exist right now without prices (I mean there's only two items right now, so it's probably not a huge deal, but it would need to be handled in the journal replay code)