### PR TITLE
Add set command and add get info by display name

### DIFF
--- a/src/word_debt_bot/cogs/game_commands.py
+++ b/src/word_debt_bot/cogs/game_commands.py
@@ -145,7 +145,7 @@ class GameCommands(commands.Cog, name="Core Gameplay"):
                 }
             )
         elif key.lower() == "languages":
-            if len(value) > 16:
+            if len(value) > 256:
                 await ctx.send("🙅 Value too long! 😔")
                 return
             self.game.set_player_languages(str(ctx.author.id), value)

--- a/src/word_debt_bot/game/core.py
+++ b/src/word_debt_bot/game/core.py
@@ -72,6 +72,16 @@ class WordDebtGame:
         else:
             return self._state.users[player_id]
 
+    def get_player_by_display_name(
+        self, display_name: str, optional=True
+    ) -> WordDebtPlayer | None:
+        for player in self._state.users.values():
+            if player.display_name == display_name:
+                return player
+        if not optional:
+            raise ValueError(f"no player with display name {display_name}")
+        return None
+
     def submit_words(
         self, player_id: str, amount: int, genre: str | None = None
     ) -> int:
@@ -86,6 +96,16 @@ class WordDebtGame:
         player.crane_payment_rollover %= 1000
         self._state = state
         return player.word_debt
+
+    def set_player_languages(self, player_id: str, languages: str):
+        state = self._state
+        state.users[player_id].languages = languages
+        self._state = state
+
+    def set_player_display_name(self, player_id: str, display_name: str):
+        state = self._state
+        state.users[player_id].display_name = display_name
+        self._state = state
 
     def add_debt(self, player_id: str, amount: int):
         if amount <= 0:

--- a/src/word_debt_bot/game/player.py
+++ b/src/word_debt_bot/game/player.py
@@ -10,3 +10,4 @@ class WordDebtPlayer:
     word_debt: int = 0
     crane_payment_rollover: int = 0
     cranes: int = 0
+    languages: str = ""

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -28,7 +28,9 @@ def test_game_migration_v0_to_v1(tmp_path: pathlib.Path):
         json.dump(state_v0, statefile)
     game_instance = game.WordDebtGame(tmp_path / "state.json")
     assert game_instance._state.version == 1
-    assert asdict(game_instance._state)["users"] == state_v0
+    migrated_state_dict = asdict(game_instance._state)["users"]
+    migrated_state_dict["197"].pop("languages")
+    assert migrated_state_dict == state_v0
 
 
 def test_game_prunes_modifiers(game_state: game.WordDebtGame):

--- a/tests/test_game_commands_cog.py
+++ b/tests/test_game_commands_cog.py
@@ -177,6 +177,17 @@ async def test_info_by_display_name(
 
 
 @pytest.mark.asyncio
+async def test_info_name_not_found(
+    game_commands_cog: cogs.GameCommands, player: game_lib.WordDebtPlayer
+):
+    ctx = AsyncMock()
+    ctx.author.id = player.user_id
+    await game_commands_cog.info(game_commands_cog, ctx, "🤪")
+
+    ctx.send.assert_called_with("Player '🤪' not found! Are they registered?")
+
+
+@pytest.mark.asyncio
 async def test_set_display_name(
     game_commands_cog: cogs.GameCommands, player: game_lib.WordDebtPlayer
 ):
@@ -188,7 +199,6 @@ async def test_set_display_name(
     assert (
         game_commands_cog.game._state.users[player.user_id].display_name == "new name"
     )
-    # assert game_commands_cog.game._state.users[player.user_id].display_name == "new name"
     ctx.send.assert_called_with("🌞 Settings updated! 🌈")
 
 
@@ -215,6 +225,34 @@ async def test_set_too_long_name(
     await game_commands_cog.set_(game_commands_cog, ctx, "name", "a" * 100)
 
     assert game_commands_cog.game._state.users[player.user_id].display_name == name
+    ctx.send.assert_called_with("🙅 Value too long! 😔")
+
+
+@pytest.mark.asyncio
+async def test_set_languages(
+    game_commands_cog: cogs.GameCommands, player: game_lib.WordDebtPlayer
+):
+    ctx = AsyncMock()
+    ctx.author.id = player.user_id
+    game_commands_cog.game.register_player(player)
+    await game_commands_cog.set_(game_commands_cog, ctx, "languages", "🇰🇿, KZ, Kazakh")
+
+    ctx.send.assert_called_with("🌞 Settings updated! 🌈")
+    assert (
+        game_commands_cog.game._state.users[player.user_id].languages
+        == "🇰🇿, KZ, Kazakh"
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_too_long_languages(
+    game_commands_cog: cogs.GameCommands, player: game_lib.WordDebtPlayer
+):
+    ctx = AsyncMock()
+    ctx.author.id = player.user_id
+    game_commands_cog.game.register_player(player)
+    await game_commands_cog.set_(game_commands_cog, ctx, "languages", "a" * 257)
+
     ctx.send.assert_called_with("🙅 Value too long! 😔")
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,7 +20,7 @@ async def test_basic_usage(bot):
 
 
 @pytest.mark.asyncio
-async def test_bonus_genre(bot):
+async def test_bonus_genre_gives_extra_cranes(bot):
     await dpytest.message(".register")
     await dpytest.message(".log 100000")
     await dpytest.empty_queue()
@@ -35,7 +35,7 @@ async def test_bonus_genre(bot):
 
 
 @pytest.mark.asyncio
-async def test_bonus_genre(bot):
+async def test_bonus_genre_no_genre_specified(bot):
     await dpytest.message(".register")
     await dpytest.message(".log 100000")
     await dpytest.empty_queue()


### PR DESCRIPTION
Closes #35

You can set your display name with `.set name 😸:angery:🥰:shibthumbsup:` and your languages with `.set languages 🇹🇼🇹🇼🇹🇼`

Info now also shows an `@` mention (without pinging) of the user and their languages

Since display names will be in the leaderboard, it makes sense to be able to search for user info by them. We could also include @ mentions in the leaderboard, but I feel like this defeats the purpose of setting your own display name