### PR TITLE
Add units to log command

### DIFF
--- a/src/word_debt_bot/cogs/game_commands.py
+++ b/src/word_debt_bot/cogs/game_commands.py
@@ -14,6 +14,8 @@ import yaml
 import word_debt_bot.client as client
 import word_debt_bot.game as game
 
+UNITS = {"words": 1.0, "zi": 1.0 / 1.5, "ji": 0.5, "hours": 8000.0}
+
 
 class GameCommands(commands.Cog, name="Core Gameplay"):
     def __init__(
@@ -168,6 +170,10 @@ class GameCommands(commands.Cog, name="Core Gameplay"):
         self,
         ctx,
         words: int = commands.parameter(description="The amount of words to log."),
+        unit: str = commands.parameter(
+            default="words",
+            description=f"The unit for logging. Options: {sorted(set(UNITS))}",
+        ),
         genre: typing.Optional[str] = commands.parameter(
             default=None,
             displayed_default=inspect.Parameter.empty,
@@ -179,6 +185,9 @@ class GameCommands(commands.Cog, name="Core Gameplay"):
 
         You can also specify a genre to potentially get bonuses. Having debt isn't necessary in order to log.
         """
+        if unit not in UNITS:
+            genre, unit = unit, "words"
+        words = round(words * UNITS.get(unit, 1.0))
         new_debt = self.game.submit_words(str(ctx.author.id), words, genre)
         journal_entry = {
             "command": "log",

--- a/src/word_debt_bot/cogs/game_commands.py
+++ b/src/word_debt_bot/cogs/game_commands.py
@@ -192,10 +192,10 @@ class GameCommands(commands.Cog, name="Core Gameplay"):
         journal_entry = {
             "command": "log",
             "words": words,
+            "unit": unit,
             "user": str(ctx.author.id),
+            "genre": genre,
         }
-        if genre:
-            journal_entry["genre"] = genre
         self.journal(journal_entry)
         await ctx.send(f"Logged {words:,} words! New debt: {new_debt:,}")
 

--- a/tests/test_err_handler.py
+++ b/tests/test_err_handler.py
@@ -41,7 +41,7 @@ async def test_submit_words_with_error(
 
     @bot.command()
     async def log_test_m1k(ctx, words=-1000):
-        await game_cmds_cog.log(ctx, words, genre=None)
+        await game_cmds_cog.log(ctx, words, unit="words", genre=None)
 
     game_cmds_cog.log_test_m1k = log_test_m1k
 
@@ -66,7 +66,7 @@ async def test_submit_words_with_no_register(
 
     @bot.command()
     async def log_test_10(ctx, words=10):
-        await game_cmds_cog.log(ctx, words, None)
+        await game_cmds_cog.log(ctx, words, "words", None)
 
     game_cmds_cog.log_test_10 = log_test_10
 

--- a/tests/test_game_commands_cog.py
+++ b/tests/test_game_commands_cog.py
@@ -50,7 +50,7 @@ async def test_submit_words(
     ctx.author.id = player.user_id
     game_commands_cog.game.register_player(player)
 
-    await game_commands_cog.log(game_commands_cog, ctx, 1000, genre=None)
+    await game_commands_cog.log(game_commands_cog, ctx, 1000, "words", genre=None)
 
     ctx.send.assert_called_with(String() & Regex("Logged 1,000 words!.*"))
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -43,3 +43,13 @@ async def test_bonus_genre_no_genre_specified(bot):
     await dpytest.message('.buy "bonus genre"')
 
     assert dpytest.verify().message().content("Must specify a genre!")
+
+
+@pytest.mark.asyncio
+async def test_units(bot):
+    await dpytest.message(".register")
+    await dpytest.message(".log 1500 zi")
+    await dpytest.message(".log 1 hours")
+    assert dpytest.verify().message().contains().content("Registered")
+    assert dpytest.verify().message().contains().content("9,000")
+    assert dpytest.verify().message().contains().content("1,000")


### PR DESCRIPTION
Adds the ability to specify units in the log command. When there's a string after the log value, it checks if that string is a unit, and applies the scaling factor if relevant. This also allows logging audiobook hours.

**Issues**
- Closes #4 
- Closes #44 
