### PR TITLE
Add cumulative words read to info output

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -630,6 +630,17 @@ files = [
 ]
 
 [[package]]
+name = "ndjson"
+version = "0.3.1"
+description = "JsonDecoder for ndjson"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ndjson-0.3.1-py2.py3-none-any.whl", hash = "sha256:839c22275e6baa3040077b83c005ac24199b94973309a8a1809be962c753a410"},
+    {file = "ndjson-0.3.1.tar.gz", hash = "sha256:bf9746cb6bb1cb53d172cda7f154c07c786d665ff28341e4e689b796b229e5d6"},
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.8.0"
 description = "Node.js virtual environment builder"
@@ -994,4 +1005,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9c120d9f2bcf86e56732d929c1d3a9ea3f6cef41834c1ff429c51cd6b071d1ca"
+content-hash = "38c842146d5b55a6223309459ae7fd0141cc7e627b03c5dfa48c0df4cb1c41ec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.10"
 beartype = "^0.16.4"
 PyYAML = "^6.0.1"
 "discord.py" = "^2.3.2"
+ndjson = "^0.3.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.4"

--- a/src/word_debt_bot/cogs/game_commands.py
+++ b/src/word_debt_bot/cogs/game_commands.py
@@ -107,12 +107,15 @@ class GameCommands(commands.Cog, name="Core Gameplay"):
             await ctx.send(f"Player '{name}' not found! Are they registered?")
             return
 
+        total = self.journal.accumulate_read(player.user_id).get(player.user_id, 0)
+
         await ctx.send(
             f"Info for <@{player.user_id}> \n"
             f"Display Name: {player.display_name}\n"
             f"Languages: {player.languages}\n"
             f"Debt: {player.word_debt:,}\n"
-            f"Cranes: {player.cranes:,}\n",
+            f"Cranes: {player.cranes:,}\n"
+            f"Total words read: {total:,}\n",
             allowed_mentions=discord.AllowedMentions.none(),
         )
 

--- a/src/word_debt_bot/game/__init__.py
+++ b/src/word_debt_bot/game/__init__.py
@@ -1,3 +1,4 @@
 from .core import WordDebtGame
+from .journal import WordDebtJournal
 from .player import WordDebtPlayer
 from .state import WordDebtState

--- a/src/word_debt_bot/game/journal.py
+++ b/src/word_debt_bot/game/journal.py
@@ -1,3 +1,4 @@
+import collections
 import json
 import pathlib
 from datetime import datetime
@@ -20,3 +21,15 @@ class WordDebtJournal:
         entry["time"] = datetime.now().timestamp()
         with open(self.journal_path, "a") as logfile:
             logfile.write(json.dumps(entry) + "\n")
+
+    def accumulate_read(self, player: str | None) -> dict[str, int]:
+        journal = self.scan()
+        counts = collections.defaultdict(lambda: 0)
+
+        for entry in filter(
+            lambda e: e["command"] == "log" and (player is None or e["user"] == player),
+            journal,
+        ):
+            counts[entry["user"]] += entry["words"]
+
+        return dict(counts)

--- a/src/word_debt_bot/game/journal.py
+++ b/src/word_debt_bot/game/journal.py
@@ -1,4 +1,6 @@
+import json
 import pathlib
+from datetime import datetime
 
 import ndjson
 
@@ -11,3 +13,10 @@ class WordDebtJournal:
         with open(self.journal_path, "r") as journal_file:
             journal = ndjson.load(journal_file)
         return journal
+
+    def append(self, entry: dict):
+        if "command" not in entry:
+            raise ValueError("entry must have a command")
+        entry["time"] = datetime.now().timestamp()
+        with open(self.journal_path, "a") as logfile:
+            logfile.write(json.dumps(entry) + "\n")

--- a/src/word_debt_bot/game/journal.py
+++ b/src/word_debt_bot/game/journal.py
@@ -1,0 +1,13 @@
+import pathlib
+
+import ndjson
+
+
+class WordDebtJournal:
+    def __init__(self, journal_path: pathlib.Path):
+        self.journal_path = journal_path
+
+    def scan(self):
+        with open(self.journal_path, "r") as journal_file:
+            journal = ndjson.load(journal_file)
+        return journal

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,5 +1,6 @@
 import random
 import string
+from typing import AsyncGenerator
 
 import discord
 import discord.ext.test as dpytest
@@ -24,7 +25,9 @@ def player() -> game.WordDebtPlayer:
 @pytest.fixture
 def game_commands_cog(game_state, tmp_path) -> cogs.GameCommands:
     bot = main.make_bot()
-    return cogs.GameCommands(bot, game_state, tmp_path / "journal.ndjson")
+    return cogs.GameCommands(
+        bot, game_state, game.WordDebtJournal(tmp_path / "journal.ndjson")
+    )
 
 
 @pytest.fixture
@@ -34,13 +37,17 @@ def cmd_err_handler_cog(game_state) -> cogs.CmdErrHandler:
 
 
 @pytest_asyncio.fixture
-async def bot(game_state, tmp_path) -> client.WordDebtBot:
+async def bot(game_state, tmp_path) -> AsyncGenerator[client.WordDebtBot, None]:
     intents = discord.Intents.default()
     intents.message_content = True
     intents.members = True
     bot = main.make_bot(intents)
     await bot._async_setup_hook()
-    await bot.add_cog(cogs.GameCommands(bot, game_state, tmp_path / "journal.ndjson"))
+    await bot.add_cog(
+        cogs.GameCommands(
+            bot, game_state, game.WordDebtJournal(tmp_path / "journal.ndjson")
+        )
+    )
     await bot.add_cog(cogs.CmdErrHandler(bot, game_state))
     dpytest.configure(bot)
 


### PR DESCRIPTION
Introduces a Journal class related to #15, and uses it to add cumulative words read to the info output. Still some work to do to add it to the leaderboard (since leaderboard doesn't construct in the same scope that the journal is available in-scope), but this can at least get us started.

Closes #25.
